### PR TITLE
enable subtomogram alignment on multiple gpus

### DIFF
--- a/pytom/gpu/gpuStructures.py
+++ b/pytom/gpu/gpuStructures.py
@@ -435,6 +435,8 @@ class GLocalAlignmentPlan():
 
         # get the shift
         peak_shift = [ip - s // 2 for ip, s in zip(interpolated_peak, self.ccc_map.shape)]
+        # get the shift without binning
+        peak_shift = [ip*self.binning for ip in peak_shift]
 
         # compared to cpu there is always a shift of 2 here... likely goes wrong before this function
         # print([ip - s // 2 for ip, s in zip(peak, self.ccc_map.shape)])


### PR DESCRIPTION
Dear PyTom developers,
    I have made a small modifications which enables the glocalsampling to utilize multiple gpus for multiple processes. This is achieved by create a copy of gpuIDs for each split on each process.  My personal test found that this modification greatly enhances the parallelism of glocaljob.

Best Regards,
Zhenwei