### PR TITLE
fixed compatability with CTF volume reconstructed by WARP

### DIFF
--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -1588,7 +1588,7 @@ class Wedge3dCTF(PyTomClass):
         if not humanUnderstandable:
             return wedge
         else:
-            return fftshift(fourier_reduced2full(wedge))
+            return fftshift(fourier_reduced2full(wedge, reduced_axis=0))
 
     def apply(self, volume, rotation=None):
 


### PR DESCRIPTION
Dear PyTOM developers,
   I noticed that there is a small bug when performing local alignment using the subtomogram and CTF reconstructed by WARP. The CTF volume reconstructed by WARP is of size (D//2+1, D, D) if the subtomogram is of size (D, D, D), i..e, the reduced axis is 0. Therefore, we should expand fourier transforms from reduced representation to full representation by specifying the reduced axis as 0. Hence, I made the modification, 
```
return fftshift(fourier_reduced2full(wedge, reduced_axis=0))
```

Best Regards,
Zhenwei